### PR TITLE
Closes #135 Recategorize/rename brand color tokens

### DIFF
--- a/design-tokens/core.yml
+++ b/design-tokens/core.yml
@@ -1,7 +1,7 @@
 ---
   imports:
     ## Components
-    - "./core/components/brand.yml"
+    - "./core/components/colors.yml"
     - "./core/components/buttons.yml"
     - "./core/components/checkboxes.yml"
     - "./core/components/font.yml"

--- a/design-tokens/core/components/colors.yml
+++ b/design-tokens/core/components/colors.yml
@@ -10,25 +10,35 @@
     ## Default Colors
     color-default:
       value: "{!COLOR_DEFAULT}"
+      category: "colors-brand"
     color-default-alt:
       value: "{!COLOR_DEFAULT_ALT}"
+      category: "colors-brand"
     color-default-contrast:
       value: "{!COLOR_DEFAULT_CONTRAST}"
+      category: "colors-brand"
 
     ## Primary Colors
     color-primary:
       value: "{!COLOR_PRIMARY}"
+      category: "colors-brand"
     color-primary-alt:
       value: "{!COLOR_PRIMARY_ALT}"
+      category: "colors-brand"
     color-primary-contrast:
       value: "{!COLOR_PRIMARY_CONTRAST}"
+      category: "colors-brand"
 
     ## Status Colors
     color-success:
       value: "{!COLOR_SUCCESS}"
+      category: "colors-status"
     color-caution:
       value: "{!COLOR_CAUTION}"
+      category: "colors-status"
     color-warning:
       value: "{!COLOR_WARNING}"
+      category: "colors-status"
     color-danger:
       value: "{!COLOR_DANGER}"
+      category: "colors-status"


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Split the core brand colors into specific categories and rename the file to not be too specific.

**Related github/jira issue (required)**:
Closes #135 

**Steps necessary to review your pull request (required)**:
- Review the file hierarchy and `core/colors.yml` has 2 token categories in it (colors-brand, colors-status)
- Make sure it builds without errors

**Note** This may need to change how the token values are "connected" on the website @jmacaluso711 