### PR TITLE
Have theo convert colors to hex codes

### DIFF
--- a/scripts/node/generate-tokens.js
+++ b/scripts/node/generate-tokens.js
@@ -72,6 +72,8 @@ glob.readdir(tokenFiles, (err, files) => {
  * @param {string} toFormat - The format to conver to
  */
 function convertFileToFormat(srcFile, toFormat) {
+  theo.registerTransform("web", ["color/hex"]);
+
   theo
     .convert({
       transform: {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Need to have [theo](https://github.com/salesforce-ux/theo) convert colors to hex instead of `rgba()`

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
1. npm run build
1. Check the `dist/` token files for hex codes instead of `rgba()`
