### PR TITLE
Deploy tokens to docs API

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build:tokens:web": "node ./scripts/node/generate-tokens.js --format=custom-properties.css,sass,raw.json,module.js",
     "build:font": "node ./scripts/node/generate-font.js",
     "pack:release": "npm run build:tokens:web && bash ./scripts/package-release.sh",
+    "deploy:prod": "npm run build:tokens:web && bash ./scripts/deploy-assets.sh -e prod",
+    "deploy:stage": "npm run build:tokens:web && bash ./scripts/deploy-assets.sh -e staging",
     "clean": "del ./dist/*/* && del ./IDS-*.zip",
     "lint:tokens:web": "./node_modules/stylelint-cli/bin/stylelint ./dist/tokens/web/*.custom-properties.css --formatter verbose; exit 0;",
     "lint:yaml": "yamllint ./**/*.yml",

--- a/scripts/deploy-assets.sh
+++ b/scripts/deploy-assets.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+RESET=`tput sgr0`
+
+BLACK=`tput setaf 0`
+RED=`tput setaf 1`
+GREEN=`tput setaf 2`
+YELLOW=`tput setaf 3`
+BLUE=`tput setaf 4`
+MAGENTA=`tput setaf 5`
+CYAN=`tput setaf 6`
+WHITE=`tput setaf 7`
+
+while getopts "v:e:f:" opt; do
+    case $opt in
+        e)
+            DEPLOY_ENV="${OPTARG}"
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+done
+
+case $DEPLOY_ENV in
+  "local") DEPLOY_URL='http://localhost/api/docs/';;
+  "localDebug") DEPLOY_URL='http://localhost:9002/api/docs/';;
+  "staging") DEPLOY_URL='https://staging.design.infor.com/api/docs/';;
+  "prod")  DEPLOY_URL='https://design.infor.com/api/docs/';;
+   *) echo "Invalid option for deploy environment";;
+esac
+
+PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
+FNAME="IDS-DEPLOY-$PACKAGE_VERSION.zip"
+
+echo "${CYAN}Zipping assets for $PACKAGE_VERSION...${RESET}"
+cd dist
+zip -r ../$FNAME \
+    tokens/
+
+cd ..
+
+echo "${CYAN}Uploading assets...${RESET}"
+
+RESPONSE=$(curl \
+  -s -o /dev/null -w "%{http_code}" \
+  --form "file=@$FNAME" \
+  --form root_path="ids-identity/$PACKAGE_VERSION"\
+  --form post_auth_key=$DOCS_API_KEY \
+  $DEPLOY_URL
+)
+
+if [ $RESPONSE == 200 ]; then
+  echo "${CYAN}Success!${RESET}"
+else
+  echo "${RED}ERROR: deploy returned http code $RESPONSE!${RESET}"
+  exit 1
+fi


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Deploys the dist token files to the Docs API so that the latest deployed version can be pulled into the website.

This script takes `dist/tokens`, zips it up, and publishes using the standard docs API mechanism we've developed.

**Related github/jira issue (required)**:
Relates to https://github.com/infor-design/website/pull/635

**Steps necessary to review your pull request (required)**:

1. Pull branch
1. Make sure `DOCS_API_KEY` environment variable is set in your current shell
2. From root, run `npm run deploy:stage`
3. You should see the script zipping, uploading, and receive a success message.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
