### PR TITLE
Adds after-release publishing script

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -9,7 +9,7 @@
     "commitMessage": "Release v%s",
     "tagAnnotation": "Release v%s",
     "beforeStartCommand": "npm run test",
-    "afterReleaseCommand": ""
+    "afterReleaseCommand": "./scripts/after-release.sh ${npm.tag} ${version}"
   },
   "npm": {
     "tag": "latest"

--- a/scripts/after-release.sh
+++ b/scripts/after-release.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# ./scripts/after-release.sh latest 4.12.1
+# ./scripts/after-release.sh beta 4.13.0-beta.0
+
+RELEASE_TAG=$1
+RELEASE_VERSION=$2
+
+if [[ "$RELEASE_TAG" == "latest" ]]; then
+    ./scripts/deploy-assets.sh -e prod
+fi


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Publishes the tokens to `prod` using the `deploy-assets.sh` script after a `release-it` release.
