### PR TITLE
235 - Fix for wrong import uri in the dark theme config

### DIFF
--- a/design-tokens/theme-soho/variants/dark/theme-soho-dark.config.json
+++ b/design-tokens/theme-soho/variants/dark/theme-soho-dark.config.json
@@ -3,7 +3,7 @@
         "design-tokens/theme-soho/color-palette.json",
         "design-tokens/theme-soho/theme.json",
 
-        "design-tokens/theme-soho/variants/contrast/theme.json",
+        "design-tokens/theme-soho/variants/dark/theme.json",
 
         "design-tokens/props/*.json",
 

--- a/design-tokens/theme-soho/variants/dark/theme.json
+++ b/design-tokens/theme-soho/variants/dark/theme.json
@@ -1,11 +1,9 @@
 {
     "theme": {
-        "shadow": {
+        "color": {
             "boxshadow": {
                 "base": { "value": "rgba(0, 0, 0, 0.4)" }
-            }
-        },
-        "color": {
+            },
             "border": {
                 "base": { "value": "{theme.color.palette.slate.40.value}" }
             },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix copy error on the dark theme config.

**Related github/jira issue (required)**:
#235 

**Steps necessary to review your pull request (required)**:
- Make sure the dark theme `$theme-color-brand-primary-base` color is the equivalent of `theme.color.palette.azure.60.value`