### PR TITLE
1249 - Fix some more theme color issues

### DIFF
--- a/design-tokens/props/button.json
+++ b/design-tokens/props/button.json
@@ -88,7 +88,7 @@
             "tertiary": {
                 "active": {
                     "font": {
-                        "value": "{theme.color.palette.graphite.100.value}"
+                        "value": "{button.color.tertiary.hover.font.value}"
                     },
                     "icon": {
                         "value": "{button.color.tertiary.active.font.value}"
@@ -96,7 +96,7 @@
                 },
                 "disabled": {
                     "font": {
-                        "value": "{theme.color.palette.graphite.60.value}"
+                        "value": "{button.color.tertiary.initial.font.value}"
                     }
                 },
                 "focus": {

--- a/design-tokens/props/checkbox.json
+++ b/design-tokens/props/checkbox.json
@@ -7,7 +7,7 @@
                         "value": "{checkbox.color.unchecked.disabled.arrow.value}"
                     },
                     "background": {
-                        "value": "{theme.color.palette.graphite.30.value}"
+                        "value": "{theme.color.palette.slate.50.value}"
                     },
                     "border": {
                         "value": "{checkbox.color.unchecked.disabled.border.value}"

--- a/design-tokens/theme-soho/variants/contrast/props/button.json
+++ b/design-tokens/theme-soho/variants/contrast/props/button.json
@@ -4,7 +4,7 @@
             "primary": {
                 "active": {
                     "background": {
-                        "value": "{theme.color.palette.azure.70.value}"
+                        "value": "{theme.color.palette.azure.80.value}"
                     }
                 },
                 "hover": {
@@ -14,55 +14,55 @@
                 },
                 "initial": {
                     "background": {
-                        "value": "{theme.color.palette.azure.60.value}"
+                        "value": "{theme.color.brand.primary.base.value}"
                     }
                 }
             },
             "secondary": {
                 "active": {
                     "background": {
-                        "value": "{theme.color.palette.slate.40.value}"
+                        "value": "{theme.color.palette.graphite.50.value}"
                     }
                 },
                 "disabled": {
                     "background": {
-                        "value": "{theme.color.palette.slate.30.value}"
+                        "value": "{button.color.secondary.initial.background.value}"
                     },
                     "border": {
-                        "value": "{theme.color.palette.slate.30.value}"
+                        "value": "{button.color.secondary.initial.background.value}"
                     },
                     "font": {
-                        "value": "{theme.color.palette.slate.100.value}"
+                        "value": "{theme.color.brand.primary.contrast.value}"
                     }
                 },
                 "hover": {
                     "background": {
-                        "value": "{theme.color.palette.slate.40.value}"
+                        "value": "{theme.color.palette.graphite.60.value}"
                     }
                 },
                 "initial": {
                     "background": {
-                        "value": "{theme.color.palette.slate.30.value}"
+                        "value": "{theme.color.palette.graphite.70.value}"
                     },
                     "font": {
-                        "value": "{theme.color.palette.slate.100.value}"
+                        "value": "{theme.color.brand.primary.contrast.value}"
                     }
                 }
             },
             "tertiary": {
                 "active": {
                     "font": {
-                        "value": "{theme.color.palette.white.value}"
+                        "value": "{button.color.tertiary.hover.font.value}"
                     }
                 },
                 "disabled": {
                     "font": {
-                        "value": "{theme.color.palette.slate.30.value}"
+                        "value": "{button.color.tertiary.hover.font.value}"
                     }
                 },
                 "hover": {
                     "font": {
-                        "value": "{theme.color.palette.white.value}"
+                        "value": "{theme.color.palette.graphite.60.value}"
                     }
                 },
                 "initial": {

--- a/design-tokens/theme-soho/variants/contrast/props/button.json
+++ b/design-tokens/theme-soho/variants/contrast/props/button.json
@@ -67,7 +67,7 @@
                 },
                 "initial": {
                     "font": {
-                        "value": "{theme.color.palette.slate.30.value}"
+                        "value": "{theme.color.palette.graphite.90.value}"
                     }
                 }
             }

--- a/design-tokens/theme-soho/variants/contrast/theme.json
+++ b/design-tokens/theme-soho/variants/contrast/theme.json
@@ -9,8 +9,8 @@
             },
             "brand": {
                 "primary": {
-                    "base":     { "value": "{theme.color.palette.azure.100.value}" },
-                    "alt":      { "value": "{theme.color.palette.azure.90.value}" }
+                    "base":     { "value": "{theme.color.palette.azure.90.value}" },
+                    "alt":      { "value": "{theme.color.palette.azure.100.value}" }
                 }
             },
             "font": {

--- a/design-tokens/theme-soho/variants/dark/props/body.json
+++ b/design-tokens/theme-soho/variants/dark/props/body.json
@@ -3,7 +3,7 @@
         "color": {
             "primary": {
                 "background": {
-                    "value": "{theme.color.palette.graphite.70.value}"
+                    "value": "{theme.color.palette.slate.80.value}"
                 },
                 "font": {
                     "value": "{theme.color.palette.white.value}"
@@ -11,7 +11,7 @@
             },
             "secondary": {
                 "background": {
-                    "value": "{theme.color.palette.graphite.20.value}"
+                    "value": "{theme.color.palette.slate.70.value}"
                 }
             }
         }

--- a/design-tokens/theme-soho/variants/dark/props/checkbox.json
+++ b/design-tokens/theme-soho/variants/dark/props/checkbox.json
@@ -7,7 +7,10 @@
                         "value": "{theme.color.brand.primary.contrast.value}"
                     },
                     "background": {
-                        "value": "{theme.color.palette.slate.50.value}"
+                        "value": "{theme.color.brand.primary.base.value}"
+                    },
+                    "border": {
+                        "value": "{checkbox.color.checked.initial.background.value}"
                     }
                 }
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ids-identity",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
We were still noticing some color oddities post-2.0 release.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/1249

**Steps necessary to review your pull request (required)**:
1. `npm run build`
1. `npm link` this branch
1. In enterprise, `npm link ids-identity`
1. Run *ids-enterprise* locally and compare the kitchen sink to the `v4.12.0` components:
    - [x] [localhost light theme](http://localhost:4000) *vs* [v4.12.0 light theme](http://4120-enterprise.demo.design.infor.com/components/button/example-index.html)
    - [x] [localhost dark theme](http://localhost:4000?theme=dark) *vs* [v4.12.0 dark theme](http://4120-enterprise.demo.design.infor.com/components/button/example-index.html?theme=dark)
    - [x] [localhost high contrast theme](http://localhost:4000?theme=high-contrast) *vs* [v4.12.0 high contrast theme](http://4120-enterprise.demo.design.infor.com/components/button/example-index.html?theme=high-contrast)

**Additional Context**

Once this patch is released, have @clepore update the corresponding *ids-enterprise* branch and create a pull request into it's `4.13.x` branch (NOT `master`).