### PR TITLE
Front - Restore the font to its previous entity

### DIFF
--- a/design-tokens/theme-soho/theme.json
+++ b/design-tokens/theme-soho/theme.json
@@ -34,7 +34,7 @@
         },
         "font": {
             "family": {
-                "base":      { "value": "'source sans pro', helvetica, arial, san-serif" },
+                "base":      { "value": "helvetica, arial, sans-serif" },
                 "monospace": { "value": "monospace" }
             }
         },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**


**Related github/jira issue (required)**:
Fixes #245

**Steps necessary to review your pull request (required)**:
1. Make sure the original themes use the correct font family of "helvetica, arial, san-serif"
    - soho theme
    - soho dark theme
    - soho high contrast theme