### PR TITLE
Update checkbox token disabled color to be lighter

### DIFF
--- a/design-tokens/props/checkbox.json
+++ b/design-tokens/props/checkbox.json
@@ -7,13 +7,13 @@
                         "value": "{checkbox.color.unchecked.disabled.arrow.value}"
                     },
                     "background": {
-                        "value": "{theme.color.palette.slate.50.value}"
+                        "value": "{checkbox.color.unchecked.disabled.border.value}"
                     },
                     "border": {
                         "value": "{checkbox.color.unchecked.disabled.border.value}"
                     },
                     "font": {
-                        "value": "{theme.color.font.muted.value}"
+                        "value": "{checkbox.color.unchecked.disabled.font.value}"
                     }
                 },
                 "initial": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ids-identity",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The disabled checked checkbox background is too dark and should be `graphite30`. 

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
Compare [v4.13.0-rc.0 checkboxes](http://4130-rc0-enterprise.demo.design.infor.com/components/checkboxes/example-index.html) to [v4.11.0 checkboxes]( https://design.infor.com/code/ids-enterprise/4.11.0/demo/components/checkboxes/example-index)

<img width="634" alt="screen shot 2018-12-05 at 12 38 11 pm" src="https://user-images.githubusercontent.com/742319/49532586-dd7e0900-f88a-11e8-860a-a6b3c662555c.png">
