### PR TITLE
Adds changelog command to prepend copy

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -5,6 +5,8 @@
   "pkgFiles": ["package.json"],
   "increment": "patch",
   "buildCommand": "npm run clean && npm run build && npm run zip",
+  "beforeChangelogCommand": "echo ${version} > /tmp/ids-identity-release-version",
+  "changelogCommand": "./scripts/github-changelog.sh",
   "src": {
     "commitMessage": "Release v%s",
     "tagAnnotation": "Release v%s",

--- a/scripts/github-changelog.sh
+++ b/scripts/github-changelog.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+REL_VERSION=$(cat /tmp/ids-identity-release-version)
+PREV_VERSION=$(git describe --tags --abbrev=0)
+if [[ "$PREV_VERSION" == "" ]]; then
+    VERSION_COMPARE=""
+else
+    VERSION_COMPARE="$PREV_VERSION...HEAD"
+fi
+LOG=$(git log --pretty=format:"* %s (%h)" $VERSION_COMPARE)
+
+if [[ "$REL_VERSION" == "" ]]; then
+    COPY="To access the assets in this release, download the IDS zip above for the latest Sketch toolkit, fonts, and more!"
+else
+    COPY="To access the assets in this release, [download IDS-$REL_VERSION.zip](https://github.com/infor-design/design-system/releases/download/$REL_VERSION/IDS-$REL_VERSION.zip) for the latest Sketch toolkit, fonts, and more!"
+    rm /tmp/ids-identity-release-version
+fi
+
+echo "$COPY"
+echo ""
+echo "$LOG"


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This is a little bit sketchy but covers for potential edge cases. Adds a `changelogCommand` which uses the same `git` command as `release-it` does to generate the change log but prepends it with some copy. The sketch part comes with the `beforeChangelogCommand`. `release-it` doesn't provide access to `${version}` within `changelogCommand` but does to `beforeChangelogCommand`, so I'm writing the version to a temp file that `changelogCommand` can read.

This allows us to directly link to the IDS asset download in the copy, which is a really nice bonus and worth the weirdness. If for some reason, the temp file can't be found, I have a fallback case. The script then removes the temp file when it's done.

**Related github/jira issue (required)**:
Closes #239

**Steps necessary to review your pull request (required)**:
Some of the necessary files aren't written in a `--dry-run` so you can't test the full thing without doing a release. If something screws up in a release, we can always just edit the Github release notes.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
