### PR TITLE
Standardize asset release

### DIFF
--- a/scripts/deploy-assets.sh
+++ b/scripts/deploy-assets.sh
@@ -31,14 +31,12 @@ case $DEPLOY_ENV in
 esac
 
 PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
-FNAME="IDS-DEPLOY-$PACKAGE_VERSION.zip"
+FNAME="IDS-$PACKAGE_VERSION.zip"
 
-echo "${CYAN}Zipping assets for $PACKAGE_VERSION...${RESET}"
-cd dist
-zip -r ../$FNAME \
-    tokens/
+echo "${CYAN}Preparing assets for $PACKAGE_VERSION...${RESET}"
 
-cd ..
+# Run package script to build `
+bash ./scripts/package-release.sh $FNAME
 
 echo "${CYAN}Uploading assets...${RESET}"
 

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,19 +1,41 @@
 #!/bin/bash
 
+RESET=`tput sgr0`
+
+BLACK=`tput setaf 0`
+RED=`tput setaf 1`
+GREEN=`tput setaf 2`
+YELLOW=`tput setaf 3`
+BLUE=`tput setaf 4`
+MAGENTA=`tput setaf 5`
+CYAN=`tput setaf 6`
+WHITE=`tput setaf 7`
+
 PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
 
 # @output zip
-# @comment Package release for Github
-#          cd into dist and get font and sketch
-#          from parent to build structure as below
+# @comment Package release for Github and Docs API
+# @argument {string} filename; has default value
 # @structure:
 #    IDS-X.X.X.zip
 #        font/
 #        sketch/
 #        tokens/
 
-cd dist
-zip -r ../IDS-$PACKAGE_VERSION.zip \
-    ../sketch/ \
-    tokens/ \
-    theme-*
+# Set zip filename to argument or fallback
+FNAME=${1:-IDS-${PACKAGE_VERSION}.zip}
+
+echo "${CYAN}Copying assets...${RESET}"
+mkdir -p deploy
+cp -r dist/* deploy
+cp -r sketch deploy
+
+echo "${CYAN}Zipping assets...${RESET}"
+cd deploy
+zip -qr ../$FNAME \
+    .
+echo "${GREEN}Created ${FNAME}${RESET}"
+
+echo "${CYAN}Cleaning up...${RESET}"
+cd ..
+rm -r deploy


### PR DESCRIPTION
Gives more control over folder structure of asset release. Standardizes by using single script for both the Github asset release and the assets deployed to docs API.