### PR TITLE
Use include and source to override colors in variants

### DIFF
--- a/design-tokens/theme-soho/variants/contrast/theme-soho-contrast.config.json
+++ b/design-tokens/theme-soho/variants/contrast/theme-soho-contrast.config.json
@@ -1,12 +1,12 @@
 {
-    "source": [
+    "include": [
         "design-tokens/theme-soho/color-palette.json",
         "design-tokens/theme-soho/theme.json",
-
+        "design-tokens/props/*.json"
+    ],
+    "source": [
         "design-tokens/theme-soho/variants/contrast/theme.json",
-
-        "design-tokens/props/*.json",
-
         "design-tokens/theme-soho/variants/contrast/props/*.json"
+
     ]
 }

--- a/design-tokens/theme-soho/variants/dark/theme-soho-dark.config.json
+++ b/design-tokens/theme-soho/variants/dark/theme-soho-dark.config.json
@@ -1,12 +1,12 @@
 {
-    "source": [
+    "include": [
         "design-tokens/theme-soho/color-palette.json",
         "design-tokens/theme-soho/theme.json",
-
+        "design-tokens/props/*.json"
+    ],
+    "source": [
         "design-tokens/theme-soho/variants/dark/theme.json",
-
-        "design-tokens/props/*.json",
-
         "design-tokens/theme-soho/variants/dark/props/*.json"
+
     ]
 }

--- a/design-tokens/theme-uplift/theme-uplift.config.json
+++ b/design-tokens/theme-uplift/theme-uplift.config.json
@@ -1,10 +1,10 @@
 {
-    "source": [
+    "include": [
         "design-tokens/theme-uplift/color-palette.json",
         "design-tokens/theme-uplift/theme.json",
-
-        "design-tokens/props/*.json",
-
+        "design-tokens/props/*.json"
+    ],
+    "source": [
         "design-tokens/theme-uplift/props/*.json"
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ids-identity",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1624,9 +1624,9 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "style-dictionary": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-2.6.2.tgz",
-      "integrity": "sha512-2uSd/8Y1fVduV1UkvkP8HwmyAV0I7lNN/gAWCd8y3xDlQFRtFgrNl2cWQkMNbS2UCbrymH0oVolQHkwDDj4fYg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-2.7.0.tgz",
+      "integrity": "sha512-DRyiFQXy8Ue3EXpCdTBBb0MCoNtfaJWf+EWKq/H0ivhgA+v1MwQXER4GRkAorJapBbuqBe7yTpPRK5Ofn7vGAQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "minimist": "^1.2.0",
     "npm-which": "^3.0.1",
     "path": "^0.12.7",
-    "style-dictionary": "^2.6.2",
+    "style-dictionary": "^2.7.0",
     "svgo": "^1.0.5"
   },
   "files": [


### PR DESCRIPTION
Uses `style-dictionary@2.7.0` feature https://github.com/amzn/style-dictionary/pull/227 to remove collision errors.

Relates to https://github.com/amzn/style-dictionary/issues/239