### PR TITLE
Updating Uplift colors 

### DIFF
--- a/design-tokens/props/body.json
+++ b/design-tokens/props/body.json
@@ -3,7 +3,7 @@
         "color": {
             "primary": {
                 "background": {
-                    "value": "{theme.color.palette.graphite.10.value}"
+                    "value": "{theme.color.body.base.value}"
                 },
                 "font": {
                     "value": "{theme.color.font.base.value}"
@@ -11,7 +11,7 @@
             },
             "secondary": {
                 "background": {
-                    "value": "{theme.color.palette.white.value}"
+                    "value": "{theme.color.body.lightest.value}"
                 }
             }
         }

--- a/design-tokens/props/button.json
+++ b/design-tokens/props/button.json
@@ -54,7 +54,7 @@
                         "value": "{theme.color.brand.secondary.base.value}"
                     },
                     "font": {
-                        "value": "{theme.color.palette.graphite.80.value}"
+                        "value": "{theme.color.border.daker.value}"
                     },
                     "opacity": {
                         "value": "{theme.number.opacity.disabled.value}"
@@ -106,7 +106,7 @@
                 },
                 "hover": {
                     "font": {
-                        "value": "{theme.color.palette.graphite.100.value}"
+                        "value": "{theme.color.font.base.value}"
                     }
                 },
                 "initial": {
@@ -114,7 +114,7 @@
                         "value": "transparent"
                     },
                     "font": {
-                        "value": "{theme.color.palette.graphite.60.value}"
+                        "value": "{theme.color.font.muted.value}"
                     },
                     "icon": {
                         "value": "{button.color.secondary.initial.font.value}"
@@ -145,7 +145,7 @@
         "shadow": {
             "focus": {
                 "boxshadow": {
-                    "value": "0 0 0 2px {theme.color.palette.graphite.10.value}, 0 0 0 3px {theme.color.brand.primary.base.value}"
+                    "value": "0 0 0 2px {theme.color.boxshadow.base.value}, 0 0 0 3px {theme.color.brand.primary.base.value}"
                 }
             }
         },

--- a/design-tokens/props/button.json
+++ b/design-tokens/props/button.json
@@ -54,7 +54,7 @@
                         "value": "{theme.color.brand.secondary.base.value}"
                     },
                     "font": {
-                        "value": "{theme.color.border.daker.value}"
+                        "value": "{theme.color.border.darker.value}"
                     },
                     "opacity": {
                         "value": "{theme.number.opacity.disabled.value}"

--- a/design-tokens/props/checkbox.json
+++ b/design-tokens/props/checkbox.json
@@ -45,7 +45,7 @@
                 },
                 "hover": {
                     "border": {
-                        "value": "{theme.color.border.daker.value}"
+                        "value": "{theme.color.border.darker.value}"
                     }
                 },
                 "initial": {

--- a/design-tokens/props/checkbox.json
+++ b/design-tokens/props/checkbox.json
@@ -37,7 +37,7 @@
                         "value": "transparent"
                     },
                     "border": {
-                        "value": "{theme.color.palette.graphite.30.value}"
+                        "value": "{theme.color.border.lighter.value}"
                     },
                     "font": {
                         "value": "{theme.color.font.muted.value}"
@@ -45,7 +45,7 @@
                 },
                 "hover": {
                     "border": {
-                        "value": "{theme.color.palette.graphite.80.value}"
+                        "value": "{theme.color.border.daker.value}"
                     }
                 },
                 "initial": {
@@ -64,7 +64,7 @@
         "shadow": {
             "focus": {
                 "boxshadow": {
-                    "value": "0 0 0 1px {theme.color.palette.graphite.10.value}, 0 0 0 2px {theme.color.brand.primary.base.value}"
+                    "value": "0 0 0 1px {theme.color.boxshadow.base.value}, 0 0 0 2px {theme.color.brand.primary.base.value}"
                 }
             }
         },

--- a/design-tokens/props/dropdown.json
+++ b/design-tokens/props/dropdown.json
@@ -8,10 +8,10 @@
                     }
                 },
                 "font": {
-                    "value": "{theme.color.palette.graphite.100.value}"
+                    "value": "{theme.color.font.base.value}"
                 },
                 "icon": {
-                    "value": "{theme.color.palette.graphite.100.value}"
+                    "value": "{dropdown.color.initial.font.value}"
                 }
             },
             "selected": {

--- a/design-tokens/props/icon.json
+++ b/design-tokens/props/icon.json
@@ -2,15 +2,15 @@
     "icon": {
         "color": {
             "fill": {
-                "value": "{theme.color.palette.graphite.40.value}"
+                "value": "{theme.color.icon.base.value}"
             }
         },
         "size": {
             "height": {
-                "value": "17px"
+                "value": "{theme.size.icon.height.value}"
             },
             "width": {
-                "value": "22px"
+                "value": "{theme.size.icon.width.value}"
             }
         }
     }

--- a/design-tokens/props/input.json
+++ b/design-tokens/props/input.json
@@ -6,10 +6,10 @@
                     "value": "transparent"
                 },
                 "border": {
-                    "value": "{theme.color.palette.graphite.30.value}"
+                    "value": "{theme.color.border.lighter.value}"
                 },
                 "font": {
-                    "value": "{theme.color.palette.graphite.40.value}"
+                    "value": "{theme.color.font.muted.value}"
                 }
             },
             "focus": {
@@ -28,7 +28,7 @@
                     "value": "transparent"
                 },
                 "border": {
-                    "value": "{theme.color.palette.graphite.80.value}"
+                    "value": "{theme.color.border.daker.value}"
                 }
             },
             "initial": {
@@ -50,13 +50,13 @@
             },
             "readonly": {
                 "background": {
-                    "value": "{theme.color.palette.graphite.20.value}"
+                    "value": "{theme.color.brand.secondary.lighter.value}"
                 },
                 "border": {
-                    "value": "{theme.color.palette.graphite.40.value}"
+                    "value": "{theme.color.border.base.value}"
                 },
                 "font": {
-                    "value": "{theme.color.palette.graphite.100.value}"
+                    "value": "{theme.color.font.base.value}"
                 }
             }
         },

--- a/design-tokens/props/input.json
+++ b/design-tokens/props/input.json
@@ -28,7 +28,7 @@
                     "value": "transparent"
                 },
                 "border": {
-                    "value": "{theme.color.border.daker.value}"
+                    "value": "{theme.color.border.darker.value}"
                 }
             },
             "initial": {

--- a/design-tokens/props/label.json
+++ b/design-tokens/props/label.json
@@ -3,7 +3,7 @@
         "color": {
             "initial": {
                 "font": {
-                    "value": "{theme.color.palette.graphite.50.value}"
+                    "value": "{theme.color.font.info.value}"
                 }
             }
         }

--- a/design-tokens/props/link.json
+++ b/design-tokens/props/link.json
@@ -3,7 +3,7 @@
         "color": {
             "disabled": {
                 "font": {
-                    "value": "{theme.color.palette.graphite.40.value}"
+                    "value": "{theme.color.font.muted.value}"
                 }
             },
             "hover": {

--- a/design-tokens/props/list.json
+++ b/design-tokens/props/list.json
@@ -17,7 +17,7 @@
                 },
                 "selected": {
                     "background": {
-                        "value": "{theme.color.palette.graphite.10.value}"
+                        "value": "{theme.color.body.base.value}"
                     }
                 }
             },

--- a/design-tokens/props/list.json
+++ b/design-tokens/props/list.json
@@ -3,13 +3,13 @@
         "color": {
             "divider": {
                 "border": {
-                    "value": "{theme.color.palette.graphite.20.value}"
+                    "value": "{theme.color.brand.secondary.lighter.value}"
                 }
             },
             "item": {
                 "hover": {
                     "background": {
-                        "value": "{theme.color.palette.graphite.20.value}"
+                        "value": "{theme.color.brand.secondary.lighter.value}"
                     }
                 },
                 "initial": {
@@ -24,7 +24,7 @@
             "heading": {
                 "initial": {
                     "font": {
-                        "value": "{theme.color.palette.graphite.20.value}"
+                        "value": "{theme.color.brand.secondary.lighter.value}"
                     }
                 }
             }

--- a/design-tokens/props/radio-button.json
+++ b/design-tokens/props/radio-button.json
@@ -4,7 +4,7 @@
             "checked": {
                 "disabled": {
                     "background": {
-                        "value": "{theme.color.palette.graphite.10.value}"
+                        "value": "{theme.color.body.base.value}"
                     },
                     "border": {
                         "value": "{radio.color.unchecked.disabled.border.value}"

--- a/design-tokens/props/radio-button.json
+++ b/design-tokens/props/radio-button.json
@@ -25,7 +25,7 @@
                         "value": "transparent"
                     },
                     "border": {
-                        "value": "{theme.color.palette.graphite.30.value}"
+                        "value": "{theme.color.border.lighter.value}"
                     },
                     "label": {
                         "value": "{theme.color.font.muted.value}"
@@ -33,7 +33,7 @@
                 },
                 "hover": {
                     "border": {
-                        "value": "{theme.color.palette.graphite.80.value}"
+                        "value": "{theme.color.border.daker.value}"
                     }
                 },
                 "initial": {
@@ -52,7 +52,7 @@
         "shadow": {
             "focus": {
                 "boxshadow": {
-                    "value": "0 0 0 1px {theme.color.palette.graphite.10.value}, 0 0 0 2px {theme.color.brand.primary.base.value}, 0 0 4px 5px rgba(54, 138, 192, 0.03)"
+                    "value": "0 0 0 1px {theme.color.boxshadow.base.value}, 0 0 0 2px {theme.color.brand.primary.base.value}, 0 0 4px 5px rgba(54, 138, 192, 0.03)"
                 }
             }
         },

--- a/design-tokens/props/radio-button.json
+++ b/design-tokens/props/radio-button.json
@@ -33,7 +33,7 @@
                 },
                 "hover": {
                     "border": {
-                        "value": "{theme.color.border.daker.value}"
+                        "value": "{theme.color.border.darker.value}"
                     }
                 },
                 "initial": {

--- a/design-tokens/theme-soho/theme.json
+++ b/design-tokens/theme-soho/theme.json
@@ -36,6 +36,10 @@
             },
             "icon": {
                 "base": { "value": "theme.color.palette.graphite.40.value" }
+            },
+            "body": {
+                "base" : { "value": "{theme.color.palette.graphite.10.value}" },
+                "lightest": { "value": "{theme.color.palette.white.value}" }
             }
         },
         "font": {

--- a/design-tokens/theme-soho/theme.json
+++ b/design-tokens/theme-soho/theme.json
@@ -35,7 +35,7 @@
                 "muted": { "value": "{theme.color.palette.graphite.40.value}" }
             },
             "icon": {
-                "base": { "value": "theme.color.palette.graphite.40.value" }
+                "base": { "value": "{theme.color.palette.graphite.40.value}" }
             },
             "body": {
                 "base" : { "value": "{theme.color.palette.graphite.10.value}" },

--- a/design-tokens/theme-soho/theme.json
+++ b/design-tokens/theme-soho/theme.json
@@ -15,6 +15,7 @@
                     "contrast": { "value": "{theme.color.palette.white.value}" }
                 },
                 "secondary": {
+                    "lighter": { "value": "{theme.color.palette.graphite.20.value}" },
                     "base":     { "value": "{theme.color.palette.graphite.30.value}" },
                     "alt":      { "value": "{theme.color.palette.graphite.40.value}" },
                     "contrast": { "value": "{theme.color.palette.graphite.80.value}" }
@@ -24,12 +25,17 @@
                 "base": { "value": "rgba(0, 0, 0, 0.2)" }
             },
             "border": {
-                "base": { "value": "{theme.color.palette.graphite.40.value}" }
+                "lighter": { "value": "{theme.color.palette.graphite.30.value}" },
+                "base": { "value": "{theme.color.palette.graphite.40.value}" },
+                "darker": { "value": "{theme.color.palette.graphite.80.value}" }
             },
             "font": {
                 "base":  { "value": "{theme.color.palette.graphite.100.value}" },
                 "info":  { "value": "{theme.color.palette.graphite.60.value}" },
                 "muted": { "value": "{theme.color.palette.graphite.40.value}" }
+            },
+            "icon": {
+                "base": { "value": "theme.color.palette.graphite.40.value" }
             }
         },
         "font": {
@@ -54,6 +60,14 @@
                             "deprecated": true
                         }
                     }
+                }
+            },
+            "icon": {
+                "height": {
+                    "value": "17px"
+                },
+                "width": {
+                    "value": "22px"
                 }
             }
         },

--- a/design-tokens/theme-uplift/color-palette.json
+++ b/design-tokens/theme-uplift/color-palette.json
@@ -3,46 +3,100 @@
         "color": {
             "palette": {
                 "amber": {
-                    "lightest": { "value": "#FDF0DD" },
-                    "lighter": { "value": "#FFC05E" },
-                    "base": { "value": "#F78300" },
-                    "darker": { "value": "#C45800" },
-                    "darkest": { "value": "#9B3300" }
+                    "10": { "value": "#FDF0DD" },
+                    "20": { "value": "#FCE6C5" },
+                    "30": { "value": "#FFD48F" },
+                    "40": { "value": "#FFC05E" },
+                    "50": { "value": "#FEA43E" },
+                    "60": { "value": "#F78300" },
+                    "70": { "value": "#E07800" },
+                    "80": { "value": "#C45800" },
+                    "90": { "value": "#9B3300" },
+                    "100": { "value": "#F78300" }
                 },
                 "amethyst": {
-                    "lightest": { "value": "#F0E8FC" },
-                    "lighter": { "value": "#977FFF" },
-                    "base": { "value": "#7834DD" },
-                    "darker": { "value": "#60209D" },
-                    "darkest": { "value": "#41166A" }
+                    "10": { "value": "#F0E8FC" },
+                    "20": { "value": "#E1D1FA" },
+                    "30": { "value": "#C1B3FF" },
+                    "40": { "value": "#977FFF" },
+                    "50": { "value": "#9668F3" },
+                    "60": { "value": "#7834DD" },
+                    "70": { "value": "#7025B6" },
+                    "80": { "value": "#60209D" },
+                    "90": { "value": "#41166A" },
+                    "100": { "value": "#39135D" }
                 },
                 "azure": {
-                    "lightest": { "value": "#E1F3FE" },
-                    "lighter": { "value": "#4AC1FE" },
-                    "base": { "value": "#0075E9" },
-                    "darker": { "value": "#0053B1" },
-                    "darkest": { "value": "#003C80" }
+                    "10": { "value": "#E1F3FE" },
+                    "20": { "value": "#C9E9FD" },
+                    "30": { "value": "#7BD3FE" },
+                    "40": { "value": "#4AC1FE" },
+                    "50": { "value": "#3399FF" },
+                    "60": { "value": "#0075E9" },
+                    "70": { "value": "#0563C2" },
+                    "80": { "value": "#0053B1" },
+                    "90": { "value": "#003C80" },
+                    "100": { "value": "#003066" }
                 },
                 "emerald": {
-                    "lightest": { "value": "#E3F7EC" },
-                    "lighter": { "value": "#7FF39C" },
-                    "base": { "value": "#35C274" },
-                    "darker": { "value": "#0A834B" },
-                    "darkest": { "value": "#065531" }
+                    "10": { "value": "#E3F7EC" },
+                    "20": { "value": "#CFF2DF" },
+                    "30": { "value": "#B0F8C2" },
+                    "40": { "value": "#7FF39C" },
+                    "50": { "value": "#67D599" },
+                    "60": { "value": "#35C274" },
+                    "70": { "value": "#2A985D" },
+                    "80": { "value": "#0A834B" },
+                    "90": { "value": "#065531" },
+                    "100": { "value": "#053E23" }
+                },
+                "graphite": {
+                    "10": { "value": "#F7F7F7" },
+                    "20": { "value": "#EBEBEB" },
+                    "30": { "value": "#D1D1D1" },
+                    "40": { "value": "#BFBFBF" },
+                    "50": { "value": "#999999" },
+                    "60": { "value": "#808080" },
+                    "70": { "value": "#666666" },
+                    "80": { "value": "#545454" },
+                    "90": { "value": "#333333" },
+                    "100": { "value": "#262626" }
                 },
                 "ruby": {
-                    "lightest": { "value": "#FCE8E8" },
-                    "lighter": { "value": "#FF7F88" },
-                    "base": { "value": "#DA1217" },
-                    "darker": { "value": "#AC1518" },
-                    "darkest": { "value": "#7B0F11" }
+                    "10": { "value": "#FCE8E8" },
+                    "20": { "value": "#FAD1D1" },
+                    "30": { "value": "#FFB3B8" },
+                    "40": { "value": "#FF7F88" },
+                    "50": { "value": "#ED4548" },
+                    "60": { "value": "#DA1217" },
+                    "70": { "value": "#CA0728" },
+                    "80": { "value": "#AC1518" },
+                    "90": { "value": "#7B0F11" },
+                    "100": { "value": "#640C0E" }
                 },
                 "slate": {
-                    "lightest": { "value": "#F7F7F8" },
-                    "lighter": { "value": "#D8D6DB" },
-                    "base": { "value": "#98949E" },
-                    "darker": { "value": "#6D6873" },
-                    "darkest": { "value": "#323036" }
+                    "10": { "value": "#F7F7F8" },
+                    "20": { "value": "#E9E9EC" },
+                    "30": { "value": "#E3E1E5" },
+                    "40": { "value": "#D8D6DB" },
+                    "50": { "value": "#BEBBC3" },
+                    "60": { "value": "#98949E" },
+                    "70": { "value": "#7A7481" },
+                    "80": { "value": "#6D6873" },
+                    "90": { "value": "#323036" },
+                    "100": { "value": "#252429" }
+                },
+                "turquoise": {
+                    "10": { "value": "#E6FAF7" },
+                    "20": { "value": "#D1F5F2" },
+                    "30": { "value": "#A8F0E4" },
+                    "40": { "value": "#79E7D5" },
+                    "50": { "value": "#78DDDD" },
+                    "60": { "value": "#50D3D3" },
+                    "70": { "value": "#31C4C4" },
+                    "80": { "value": "#2EB3B8" },
+                    "90": { "value": "#248B8F" },
+                    "100": { "value": "#1F777A" }
                 },
                 "white": { "value": "#ffffff" },
                 "black": { "value": "#000000" }

--- a/design-tokens/theme-uplift/color-palette.json
+++ b/design-tokens/theme-uplift/color-palette.json
@@ -3,100 +3,46 @@
         "color": {
             "palette": {
                 "amber": {
-                    "10": { "value": "#fceccf" },
-                    "20": { "value": "#fadca8" },
-                    "30": { "value": "#f8cd81" },
-                    "40": { "value": "#f6bd5a" },
-                    "50": { "value": "#f4ae34" },
-                    "60": { "value": "#f29e0d" },
-                    "70": { "value": "#cb850b" },
-                    "80": { "value": "#a56c09" },
-                    "90": { "value": "#7e5207" },
-                    "100": { "value": "#573905" }
+                    "lightest": { "value": "#FDF0DD" },
+                    "lighter": { "value": "#FFC05E" },
+                    "base": { "value": "#F78300" },
+                    "darker": { "value": "#C45800" },
+                    "darkest": { "value": "#9B3300" }
                 },
                 "amethyst": {
-                    "10": { "value": "#e6daf1" },
-                    "20": { "value": "#d1bce6" },
-                    "30": { "value": "#bd9fdb" },
-                    "40": { "value": "#a881cf" },
-                    "50": { "value": "#9464c4" },
-                    "60": { "value": "#8046b9" },
-                    "70": { "value": "#6b3b9b" },
-                    "80": { "value": "#57307e" },
-                    "90": { "value": "#422460" },
-                    "100": { "value": "#2e1943" }
+                    "lightest": { "value": "#F0E8FC" },
+                    "lighter": { "value": "#977FFF" },
+                    "base": { "value": "#7834DD" },
+                    "darker": { "value": "#60209D" },
+                    "darkest": { "value": "#41166A" }
                 },
                 "azure": {
-                    "10": { "value": "#d1dffa" },
-                    "20": { "value": "#acc5f6" },
-                    "30": { "value": "#88abf2" },
-                    "40": { "value": "#6391ee" },
-                    "50": { "value": "#3e77ea" },
-                    "60": { "value": "#195ee6" },
-                    "70": { "value": "#154fc1" },
-                    "80": { "value": "#11409c" },
-                    "90": { "value": "#0d3177" },
-                    "100": { "value": "#092253" }
+                    "lightest": { "value": "#E1F3FE" },
+                    "lighter": { "value": "#4AC1FE" },
+                    "base": { "value": "#0075E9" },
+                    "darker": { "value": "#0053B1" },
+                    "darkest": { "value": "#003C80" }
                 },
                 "emerald": {
-                    "10": { "value": "#d6f5d6" },
-                    "20": { "value": "#b6edb6" },
-                    "30": { "value": "#95e495" },
-                    "40": { "value": "#74dc74" },
-                    "50": { "value": "#54d454" },
-                    "60": { "value": "#33cc33" },
-                    "70": { "value": "#2bab2b" },
-                    "80": { "value": "#238b23" },
-                    "90": { "value": "#1b6a1b" },
-                    "100": { "value": "#124a12" }
-                },
-                "graphite": {
-                    "10": { "value": "#f7f7f7" },
-                    "20": { "value": "#d9d9d9" },
-                    "30": { "value": "#bababa" },
-                    "40": { "value": "#9c9c9c" },
-                    "50": { "value": "#7d7d7d" },
-                    "60": { "value": "#595959" },
-                    "70": { "value": "#474747" },
-                    "80": { "value": "#363636" },
-                    "90": { "value": "#242424" },
-                    "100": { "value": "#121212" }
+                    "lightest": { "value": "#E3F7EC" },
+                    "lighter": { "value": "#7FF39C" },
+                    "base": { "value": "#35C274" },
+                    "darker": { "value": "#0A834B" },
+                    "darkest": { "value": "#065531" }
                 },
                 "ruby": {
-                    "10": { "value": "#f7d4d7" },
-                    "20": { "value": "#f1b1b6" },
-                    "30": { "value": "#eb8e96" },
-                    "40": { "value": "#e56c76" },
-                    "50": { "value": "#df4955" },
-                    "60": { "value": "#d92635" },
-                    "70": { "value": "#b6202d" },
-                    "80": { "value": "#931a24" },
-                    "90": { "value": "#71141c" },
-                    "100": { "value": "#880e0e" }
+                    "lightest": { "value": "#FCE8E8" },
+                    "lighter": { "value": "#FF7F88" },
+                    "base": { "value": "#DA1217" },
+                    "darker": { "value": "#AC1518" },
+                    "darkest": { "value": "#7B0F11" }
                 },
                 "slate": {
-                    "10": { "value": "#f6f7f8" },
-                    "20": { "value": "#d3d6de" },
-                    "30": { "value": "#b0b5c4" },
-                    "40": { "value": "#8d95aa" },
-                    "50": { "value": "#6a7490" },
-                    "60": { "value": "#4c5367" },
-                    "70": { "value": "#3d4252" },
-                    "80": { "value": "#2e323e" },
-                    "90": { "value": "#1e2129" },
-                    "100": { "value": "#0f1115" }
-                },
-                "turquoise": {
-                    "10": { "value": "#d4f7f0" },
-                    "20": { "value": "#b1f1e3" },
-                    "30": { "value": "#8eebd7" },
-                    "40": { "value": "#6ce5cb" },
-                    "50": { "value": "#49dfbe" },
-                    "60": { "value": "#26d9b2" },
-                    "70": { "value": "#20b696" },
-                    "80": { "value": "#1a9379" },
-                    "90": { "value": "#14715d" },
-                    "100": { "value": "#0d4e40" }
+                    "lightest": { "value": "#F7F7F8" },
+                    "lighter": { "value": "#D8D6DB" },
+                    "base": { "value": "#98949E" },
+                    "darker": { "value": "#6D6873" },
+                    "darkest": { "value": "#323036" }
                 },
                 "white": { "value": "#ffffff" },
                 "black": { "value": "#000000" }

--- a/design-tokens/theme-uplift/props/input.json
+++ b/design-tokens/theme-uplift/props/input.json
@@ -11,12 +11,12 @@
                     "value": "{theme.color.palette.white.value}"
                 },
                 "placeholder": {
-                    "value": "{theme.color.palette.slate.darker.value}"
+                    "value": "{theme.color.palette.slate.80.value}"
                 }
             },
             "readonly": {
                 "font": {
-                    "value": "{theme.color.palette.slate.darkest.value}"
+                    "value": "{theme.color.palette.slate.80.value}"
                 }
             }
         },

--- a/design-tokens/theme-uplift/props/input.json
+++ b/design-tokens/theme-uplift/props/input.json
@@ -11,12 +11,12 @@
                     "value": "{theme.color.palette.white.value}"
                 },
                 "placeholder": {
-                    "value": "{theme.color.palette.graphite.60.value}"
+                    "value": "{theme.color.palette.slate.darker.value}"
                 }
             },
             "readonly": {
                 "font": {
-                    "value": "{theme.color.palette.graphite.100.value}"
+                    "value": "{theme.color.palette.slate.darkest.value}"
                 }
             }
         },

--- a/design-tokens/theme-uplift/theme.json
+++ b/design-tokens/theme-uplift/theme.json
@@ -36,6 +36,10 @@
             },
             "icon": {
                 "base": { "value": "theme.color.palette.slate.darker.value" }
+            },
+            "body": {
+                "base" : { "value": "{theme.color.palette.slate.lightest.value}" },
+                "lightest": { "value": "{theme.color.palette.white.value}" }
             }
         },
         "font": {

--- a/design-tokens/theme-uplift/theme.json
+++ b/design-tokens/theme-uplift/theme.json
@@ -5,40 +5,40 @@
                 "base":    { "value": "{theme.color.brand.primary.alt.value}" },
                 "caution": { "value": "#FFD100" },
                 "danger":  { "value": "#DA1217" },
-                "success": { "value": "#33cc33" },
+                "success": { "value": "#35C274" },
                 "warning": { "value": "#F78300" }
             },
             "brand": {
                 "primary": {
-                    "base":     { "value": "{theme.color.palette.azure.base.value}" },
-                    "alt":      { "value": "{theme.color.palette.azure.darker.value}" },
+                    "base":     { "value": "{theme.color.palette.azure.60.value}" },
+                    "alt":      { "value": "{theme.color.palette.azure.70.value}" },
                     "contrast": { "value": "{theme.color.palette.white.value}" }
                 },
                 "secondary": {
-                    "lighter": { "value": "{theme.color.palette.slate.lighter.value}" },
-                    "base":     { "value": "{theme.color.palette.slate.base.value}" },
-                    "alt":      { "value": "{theme.color.palette.slate.darker.value}" },
-                    "contrast": { "value": "{theme.color.palette.slate.darkest.value}" }
+                    "lighter": { "value": "{theme.color.palette.slate.40.value}" },
+                    "base":     { "value": "{theme.color.palette.slate.60.value}" },
+                    "alt":      { "value": "{theme.color.palette.slate.80.value}" },
+                    "contrast": { "value": "{theme.color.palette.slate.90.value}" }
                 }
             },
             "boxshadow": {
-                "base": { "value": "{theme.color.palette.slate.lightest.value}" }
+                "base": { "value": "{theme.color.palette.slate.10.value}" }
             },
             "border": {
-                "lighter": { "value": "{theme.color.palette.slate.lighter.value}" },
-                "base": { "value": "{theme.color.palette.slate.darker.value}" },
-                "darker": { "value": "{theme.color.palette.slate.darker.value}" }
+                "lighter": { "value": "{theme.color.palette.slate.60.value}" },
+                "base": { "value": "{theme.color.palette.slate.80.value}" },
+                "darker": { "value": "{theme.color.palette.slate.90.value}" }
             },
             "font": {
-                "base":  { "value": "{theme.color.palette.slate.darkest.value}" },
-                "info":  { "value": "{theme.color.palette.slate.darker.value}" },
-                "muted": { "value": "{theme.color.palette.slate.base.value}" }
+                "base":  { "value": "{theme.color.palette.slate.100.value}" },
+                "info":  { "value": "{theme.color.palette.slate.80.value}" },
+                "muted": { "value": "{theme.color.palette.slate.60.value}" }
             },
             "icon": {
-                "base": { "value": "theme.color.palette.slate.darker.value" }
+                "base": { "value": "{theme.color.palette.slate.80.value}" }
             },
             "body": {
-                "base" : { "value": "{theme.color.palette.slate.lightest.value}" },
+                "base" : { "value": "{theme.color.palette.slate.10.value}" },
                 "lightest": { "value": "{theme.color.palette.white.value}" }
             }
         },

--- a/design-tokens/theme-uplift/theme.json
+++ b/design-tokens/theme-uplift/theme.json
@@ -3,39 +3,39 @@
         "color": {
             "status": {
                 "base":    { "value": "{theme.color.brand.primary.alt.value}" },
-                "caution": { "value": "#ffd000" },
-                "danger":  { "value": "#d92635" },
+                "caution": { "value": "#FFD100" },
+                "danger":  { "value": "#DA1217" },
                 "success": { "value": "#33cc33" },
-                "warning": { "value": "#f29e0d" }
+                "warning": { "value": "#F78300" }
             },
             "brand": {
                 "primary": {
-                    "base":     { "value": "{theme.color.palette.azure.60.value}" },
-                    "alt":      { "value": "{theme.color.palette.azure.70.value}" },
+                    "base":     { "value": "{theme.color.palette.azure.base.value}" },
+                    "alt":      { "value": "{theme.color.palette.azure.darker.value}" },
                     "contrast": { "value": "{theme.color.palette.white.value}" }
                 },
                 "secondary": {
-                    "lighter": { "value": "{theme.color.palette.graphite.20.value}" },
-                    "base":     { "value": "{theme.color.palette.graphite.30.value}" },
-                    "alt":      { "value": "{theme.color.palette.graphite.40.value}" },
-                    "contrast": { "value": "{theme.color.palette.graphite.80.value}" }
+                    "lighter": { "value": "{theme.color.palette.slate.lighter.value}" },
+                    "base":     { "value": "{theme.color.palette.slate.base.value}" },
+                    "alt":      { "value": "{theme.color.palette.slate.darker.value}" },
+                    "contrast": { "value": "{theme.color.palette.slate.darkest.value}" }
                 }
             },
             "boxshadow": {
-                "base": { "value": "{theme.color.palette.graphite.10.value}" }
+                "base": { "value": "{theme.color.palette.slate.lightest.value}" }
             },
             "border": {
-                "lighter": { "value": "{theme.color.palette.graphite.30.value}" },
-                "base": { "value": "{theme.color.palette.graphite.60.value}" },
-                "darker": { "value": "{theme.color.palette.graphite.80.value}" }
+                "lighter": { "value": "{theme.color.palette.slate.lighter.value}" },
+                "base": { "value": "{theme.color.palette.slate.darker.value}" },
+                "darker": { "value": "{theme.color.palette.slate.darker.value}" }
             },
             "font": {
-                "base":  { "value": "{theme.color.palette.graphite.100.value}" },
-                "info":  { "value": "{theme.color.palette.graphite.80.value}" },
-                "muted": { "value": "{theme.color.palette.graphite.60.value}" }
+                "base":  { "value": "{theme.color.palette.slate.darkest.value}" },
+                "info":  { "value": "{theme.color.palette.slate.darker.value}" },
+                "muted": { "value": "{theme.color.palette.slate.base.value}" }
             },
             "icon": {
-                "base": { "value": "theme.color.palette.graphite.40.value" }
+                "base": { "value": "theme.color.palette.slate.darker.value" }
             }
         },
         "font": {

--- a/design-tokens/theme-uplift/theme.json
+++ b/design-tokens/theme-uplift/theme.json
@@ -15,6 +15,7 @@
                     "contrast": { "value": "{theme.color.palette.white.value}" }
                 },
                 "secondary": {
+                    "lighter": { "value": "{theme.color.palette.graphite.20.value}" },
                     "base":     { "value": "{theme.color.palette.graphite.30.value}" },
                     "alt":      { "value": "{theme.color.palette.graphite.40.value}" },
                     "contrast": { "value": "{theme.color.palette.graphite.80.value}" }
@@ -24,12 +25,17 @@
                 "base": { "value": "{theme.color.palette.graphite.10.value}" }
             },
             "border": {
-                "base": { "value": "{theme.color.palette.graphite.60.value}" }
+                "lighter": { "value": "{theme.color.palette.graphite.30.value}" },
+                "base": { "value": "{theme.color.palette.graphite.60.value}" },
+                "darker": { "value": "{theme.color.palette.graphite.80.value}" }
             },
             "font": {
                 "base":  { "value": "{theme.color.palette.graphite.100.value}" },
                 "info":  { "value": "{theme.color.palette.graphite.80.value}" },
                 "muted": { "value": "{theme.color.palette.graphite.60.value}" }
+            },
+            "icon": {
+                "base": { "value": "theme.color.palette.graphite.40.value" }
             }
         },
         "font": {
@@ -54,6 +60,14 @@
                             "deprecated": true
                         }
                     }
+                }
+            },
+            "icon": {
+                "height": {
+                    "value": "17px"
+                },
+                "width": {
+                    "value": "22px"
                 }
             }
         },

--- a/scripts/node/build-icons.js
+++ b/scripts/node/build-icons.js
@@ -64,7 +64,7 @@ const customSvgoNonScalingStroke = {
 const customSvgoFillStroke = {
   type        : 'perItem',
   fn          : item => {
-    if (item.hasAttr('fill')) {
+    if (item.hasAttr('fill') && ! item.hasAttr('vector-effect')) {
       item.addAttr({
         name: 'stroke',
         value: 'none',

--- a/scripts/node/build-icons.js
+++ b/scripts/node/build-icons.js
@@ -150,7 +150,7 @@ function sortByFileFormat(srcDir, format) {
   // Loop through and move each file
   const promises = files.map(f => {
     return new Promise((resolve, reject) => {
-      const filename = path.basename(f);
+      const filename = path.basename(f).toLowerCase();
       const reg = /[\w-]+-(16|24|32)\.[\w]+/;
       const match = filename.match(reg);
       let thisDest = dest;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added additional values to the Uplift color palette to match the SoHo color palette of 8 hues and 10 variations.

**Related github/jira issue (required)**:
Closes #261 

**Steps necessary to review your pull request (required)**:
n/a

---

*Note this is a fixed PR for https://github.com/infor-design/design-system/pull/289*
