### PR TITLE
v2 and v3 token compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ids-identity",
-  "version": "3.0.0-dev",
+  "version": "2.3.0-dev",
   "description": "Infor Design System Design Assets",
   "scripts": {
     "sketch:diff": "./scripts/skdiff -o ./.tmp/ ",

--- a/scripts/node/build.js
+++ b/scripts/node/build.js
@@ -15,6 +15,7 @@ const gIcons = require('./build-icons');
 const gFonts = require('./build-font');
 const gTokens = require('./build-tokens');
 const compareTokens = require('./utilities/compare-tokens');
+const pkgjson = require('../../package.json');
 
 const themesArr = ['theme-soho', 'theme-uplift'];
 
@@ -51,7 +52,9 @@ async function runSync(arr) {
 //   Main
 // -------------------------------------
 
-// CLean up dist
+const isVersionThreeOrNewer = parseInt(pkgjson.version.charAt(0)) > 2;
+
+// Clean up dist
 const rootDest = './dist';
 del.sync([rootDest]);
 createDirs([rootDest]);
@@ -92,13 +95,23 @@ themesArr.forEach(theme => {
 
   const tokensSrc = `./design-tokens/${theme}`;
   if (args.build.includes('tokens') && fs.existsSync(tokensSrc)) {
-    const dest = `${themeDest}/tokens`;
+    let dest = `${rootDest}/tokens`;
+
+    if (isVersionThreeOrNewer) {
+      dest = `${themeDest}/tokens`;
+    }
     createDirs([dest]);
 
     promises.push(() => {
       return gTokens(tokensSrc, dest).then(() => {
+        let tokensToCompare = `${dest}/web/theme-*.simple.json`;
+
+        if (isVersionThreeOrNewer) {
+          tokensToCompare = `${rootDest}/*/tokens/web/theme-*.simple.json`;
+        }
+
         // Verify/validate token files against eachother
-        return compareTokens(`${rootDest}/*/tokens/web/theme-*.simple.json`).catch(console.error);
+        return compareTokens(tokensToCompare).catch(console.error);
       });
     });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
We originally set `master` branch up to be `v3.0` but realized we might need some more `v2` work, so it needs to be backwards compatible.

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
- Test for `v2`
    1. `npm run build:tokens`
    2. See that the `dist/` has tokens in root `/`
- Test for `v3`
    1. Temporarily change the package.json version to `3.0.0` (as long as first digit `> 2`)
    2. `npm run build:tokens`
    3. See that the tokens are now in their right `dist/theme-{theme}` hierarchy

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
