### PR TITLE
312 - HTML5 standards don't allow self-closing tags

### DIFF
--- a/scripts/node/build-icons.js
+++ b/scripts/node/build-icons.js
@@ -248,6 +248,7 @@ function optimizeSVGs(src) {
 
   // Optimize with svgo:
   const svgoOptimize = new svgo({
+    js2svg: { useShortTags: false },
     plugins: [
       { removeViewBox: false },
       { convertColors: { currentColor: '#000000' }},


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
SVGO automatically uses a self-close tag for svgs. For once IE is giving a useful warning about sticking to HTML5 standards and using closing tags for non-void HTML elements ([referenced here](https://stackoverflow.com/questions/28948210/how-to-avoid-html1500-tag-cannot-be-self-closing-warning-in-ie-when-using-embedd)

**Related github/jira issue (required)**:
#312 

**Steps necessary to review your pull request (required)**:
1. 'npm run build:icons'
1. View `dist/` of any svg file and make sure `<path ...></path>` is closed.