### PR TITLE
295 - Update soho theme to match current font sizes

### DIFF
--- a/design-tokens/theme-soho/theme.json
+++ b/design-tokens/theme-soho/theme.json
@@ -50,12 +50,12 @@
         },
         "size": {
             "font": {
-                "base": { "value": "{theme.size.font.sm.value}" },
-                "xs":   { "value": "1.2rem" },
-                "sm":   { "value": "1.4rem" },
-                "md":   { "value": "2.4rem" },
-                "lg":   { "value": "3.2rem" },
-                "xl":   { "value": "4.0rem" },
+                "base": { "value": "{theme.size.font.md.value}" },
+                "xs":   { "value": "1.0rem" },
+                "sm":   { "value": "1.2rem" },
+                "md":   { "value": "1.4rem" },
+                "lg":   { "value": "1.8rem" },
+                "xl":   { "value": "2.4rem" },
                 "line": {
                     "height": {
                         "value": "2.2rem",


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The font sizes depicted in the current tokens do not represent what exists in the Enterprise Soho theme.

**Related github/jira issue (required)**:
#295 

**Steps necessary to review your pull request (required)**:
1. build and `npm link` ids-identity
1. `npm link` ids-identity in Enterprise and then checkout the [associated branch](https://github.com/infor-design/enterprise/pull/1751) and run local enterprise to hopefully not see changes.


<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
