### PR TITLE
Uses lighter value to avoid using opacity

### DIFF
--- a/design-tokens/props/button.json
+++ b/design-tokens/props/button.json
@@ -48,16 +48,16 @@
                 },
                 "disabled": {
                     "background": {
-                        "value": "{theme.color.brand.secondary.alt.value}"
+                        "value": "{theme.color.brand.secondary.lighter.value}"
                     },
                     "border": {
-                        "value": "{theme.color.brand.secondary.base.value}"
+                        "value": "{theme.color.brand.secondary.lighter.value}"
                     },
                     "font": {
-                        "value": "{theme.color.border.darker.value}"
+                        "value": "{theme.color.brand.secondary.alt.value}"
                     },
-                    "opacity": {
-                        "value": "{theme.number.opacity.disabled.value}"
+                    "icon": {
+                        "value": "{theme.color.brand.secondary.alt.value}"
                     }
                 },
                 "focus": {

--- a/design-tokens/props/button.json
+++ b/design-tokens/props/button.json
@@ -15,10 +15,10 @@
                         "value": "{theme.color.palette.azure.30.value}"
                     },
                     "font": {
-                        "value": "{theme.color.palette.white.value}"
+                        "value": "{theme.color.palette.graphite.10.value}"
                     },
                     "icon": {
-                        "value": "{theme.color.palette.white.value}"
+                        "value": "{theme.color.palette.graphite.10.value}"
                     }
                 },
                 "focus": {

--- a/design-tokens/props/button.json
+++ b/design-tokens/props/button.json
@@ -9,10 +9,16 @@
                 },
                 "disabled": {
                     "background": {
-                        "value": "{theme.color.brand.primary.base.value}"
+                        "value": "{theme.color.palette.azure.30.value}"
                     },
                     "border": {
-                        "value": "{theme.color.brand.primary.base.value}"
+                        "value": "{theme.color.palette.azure.30.value}"
+                    },
+                    "font": {
+                        "value": "{theme.color.palette.white.value}"
+                    },
+                    "icon": {
+                        "value": "{theme.color.palette.white.value}"
                     }
                 },
                 "focus": {
@@ -58,6 +64,13 @@
                     },
                     "icon": {
                         "value": "{theme.color.brand.secondary.alt.value}"
+                    },
+                    "opacity": {
+                        "value": "{theme.number.opacity.disabled.value}",
+                        "comment": "DEPRECATED: Use theme.number.opacity.disabled.value instead.",
+                        "attributes": {
+                            "deprecated": true
+                        }
                     }
                 },
                 "focus": {
@@ -96,8 +109,12 @@
                 },
                 "disabled": {
                     "font": {
-                        "value": "{button.color.tertiary.initial.font.value}"
+                        "value": "{theme.color.brand.secondary.alt.value}"
+                    },
+                    "icon": {
+                        "value": "{theme.color.brand.secondary.alt.value}"
                     }
+
                 },
                 "focus": {
                     "font": {

--- a/design-tokens/theme-soho/variants/contrast/props/button.json
+++ b/design-tokens/theme-soho/variants/contrast/props/button.json
@@ -7,6 +7,20 @@
                         "value": "{theme.color.palette.azure.80.value}"
                     }
                 },
+                "disabled": {
+                    "background": {
+                        "value": "{theme.color.palette.azure.70.value}"
+                    },
+                    "border": {
+                        "value": "{theme.color.palette.azure.70.value}"
+                    },
+                    "font": {
+                        "value": "{theme.color.palette.slate.30.value}"
+                    },
+                    "icon": {
+                        "value": "{theme.color.palette.slate.30.value}"
+                    }
+                },
                 "hover": {
                     "background": {
                         "value": "{theme.color.palette.azure.80.value}"
@@ -26,13 +40,16 @@
                 },
                 "disabled": {
                     "background": {
-                        "value": "{button.color.secondary.initial.background.value}"
+                        "value": "{theme.color.palette.graphite.30.value}"
                     },
                     "border": {
-                        "value": "{button.color.secondary.initial.background.value}"
+                        "value": "{theme.color.palette.graphite.30.value}"
                     },
                     "font": {
-                        "value": "{theme.color.brand.primary.contrast.value}"
+                        "value": "{theme.color.palette.graphite.50.value}"
+                    },
+                    "icon": {
+                        "value": "{theme.color.palette.graphite.50.value}"
                     }
                 },
                 "hover": {
@@ -55,11 +72,6 @@
                         "value": "{button.color.tertiary.hover.font.value}"
                     }
                 },
-                "disabled": {
-                    "font": {
-                        "value": "{button.color.tertiary.hover.font.value}"
-                    }
-                },
                 "hover": {
                     "font": {
                         "value": "{theme.color.palette.graphite.60.value}"
@@ -68,6 +80,14 @@
                 "initial": {
                     "font": {
                         "value": "{theme.color.palette.graphite.90.value}"
+                    }
+                },
+                "disabled": {
+                    "font": {
+                        "value": "{theme.color.palette.graphite.50.value}"
+                    },
+                    "icon": {
+                        "value": "{theme.color.palette.graphite.50.value}"
                     }
                 }
             }

--- a/design-tokens/theme-soho/variants/dark/props/button.json
+++ b/design-tokens/theme-soho/variants/dark/props/button.json
@@ -16,6 +16,20 @@
                     "background": {
                         "value": "{theme.color.palette.azure.80.value}"
                     }
+                },
+                "disabled": {
+                    "background": {
+                        "value": "{theme.color.palette.azure.90.value}"
+                    },
+                    "border": {
+                        "value": "{theme.color.palette.azure.90.value}"
+                    },
+                    "font": {
+                        "value": "{theme.color.palette.slate.40.value}"
+                    },
+                    "icon": {
+                        "value": "{theme.color.palette.slate.40.value}"
+                    }
                 }
             },
             "secondary": {
@@ -34,13 +48,16 @@
                 },
                 "disabled": {
                     "background": {
-                        "value": "{theme.color.palette.slate.30.value}"
+                        "value": "{theme.color.palette.slate.50.value}"
                     },
                     "border": {
-                        "value": "{theme.color.palette.slate.30.value}"
+                        "value": "{theme.color.palette.slate.50.value}"
                     },
                     "font": {
-                        "value": "{theme.color.palette.slate.100.value}"
+                        "value": "{theme.color.palette.slate.80.value}"
+                    },
+                    "icon": {
+                        "value": "{theme.color.palette.slate.80.value}"
                     }
                 },
                 "focus": {
@@ -70,7 +87,10 @@
                 },
                 "disabled": {
                     "font": {
-                        "value": "{theme.color.palette.slate.30.value}"
+                        "value": "{theme.color.palette.slate.50.value}"
+                    },
+                    "icon": {
+                        "value": "{theme.color.palette.slate.50.value}"
                     }
                 },
                 "hover": {

--- a/design-tokens/theme-uplift/props/button.json
+++ b/design-tokens/theme-uplift/props/button.json
@@ -9,6 +9,50 @@
                     "value": "{theme.number.border.radius.md.value}"
                 }
             }
+        },
+        "color": {
+            "primary": {
+                "disabled": {
+                    "background": {
+                        "value": "{theme.color.palette.azure.30.value}"
+                    },
+                    "border": {
+                        "value": "{theme.color.palette.azure.30.value}"
+                    },
+                    "font": {
+                        "value": "{theme.color.palette.graphite.10.value}"
+                    },
+                    "icon": {
+                        "value": "{theme.color.palette.graphite.10.value}"
+                    }
+                }
+            },
+            "secondary": {
+                "disabled": {
+                    "background": {
+                        "value": "{theme.color.palette.slate.40.value}"
+                    },
+                    "border": {
+                        "value": "{theme.color.palette.slate.40.value}"
+                    },
+                    "font": {
+                        "value": "{theme.color.palette.slate.60.value}"
+                    },
+                    "icon": {
+                        "value": "{theme.color.palette.slate.60.value}"
+                    }
+                }
+            },
+            "tertiary": {
+                "disabled": {
+                    "font": {
+                        "value": "{theme.color.palette.slate.60.value}"
+                    },
+                    "icon": {
+                        "value": "{theme.color.palette.slate.60.value}"
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Uses different colors and moves away from using opacity on buttons.

**Related github/jira issue (required)**:
Closes #354, enables https://github.com/infor-design/enterprise/issues/1914

**Steps necessary to review your pull request (required)**:
1. Make sure `npm run build` doesn't error.
1. Design-system repo:
    1. Run `npm run build`
    1. Run `npm link`
1. Enterprise repo:
    1. Checkout branch `1914-remove-btn-opacity`
    1. Run `npm i`
    1. Run `npm link ids-identity`
    1. Run `npm start`
1. Compare the following links:

| Localhost | v4.17.1 |
| --------- | ------- |
| [Light Theme](http://localhost:4000/) | [Light Theme](https://4171-enterprise.demo.design.infor.com) |
| [Dark Theme](http://localhost:4000/?theme=dark) | [Dark Theme](https://4171-enterprise.demo.design.infor.com?theme=dark) |
| [High Contrast Theme](http://localhost:4000/?theme=high-contrast) | [High Contrast Theme](https://4171-enterprise.demo.design.infor.com?theme=high-contrast) |
| [Uplift Theme](http://localhost:4000/?theme=uplift) | [Uplift Theme](https://4171-enterprise.demo.design.infor.com?theme=uplift) |
