### PR TITLE
Change Uplift Light's input placeholder color to be lighter [v2.6.x]

### DIFF
--- a/design-tokens/theme-uplift/props/input.json
+++ b/design-tokens/theme-uplift/props/input.json
@@ -11,7 +11,7 @@
                     "value": "{theme.color.palette.white.value}"
                 },
                 "placeholder": {
-                    "value": "{theme.color.palette.slate.80.value}"
+                    "value": "{theme.color.palette.slate.60.value}"
                 }
             },
             "readonly": {


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR increases the difference in font color between an input field's placeholder text and actual text.

**Related github/jira issue (required):**
- Originally reported in infor-design/enterprise#2528
- Closes #393

**Steps necessary to review your pull request (required):**
TBD

**Additional Context**
This PR supersedes #394, which was committed against `master`, whereas this PR will be pushed to `2.6.x`