### PR TITLE
404 - more color changes

### DIFF
--- a/design-tokens/theme-uplift/props/input.json
+++ b/design-tokens/theme-uplift/props/input.json
@@ -2,6 +2,9 @@
     "input": {
         "color": {
             "disabled": {
+                "border": {
+                    "value": "{theme.color.palette.slate.40.value}"
+                },
                 "background": {
                     "value": "{theme.color.palette.white.value}"
                 }

--- a/design-tokens/theme-uplift/variants/contrast/props/button.json
+++ b/design-tokens/theme-uplift/variants/contrast/props/button.json
@@ -4,32 +4,32 @@
             "primary": {
                 "disabled": {
                     "background": {
-                        "value": "{theme.color.palette.azure.70.value}"
+                        "value": "{theme.color.palette.azure.50.value}"
                     },
                     "border": {
-                        "value": "{theme.color.palette.azure.70.value}"
+                        "value": "{theme.color.palette.azure.50.value}"
                     },
                     "font": {
-                        "value": "{theme.color.palette.slate.40.value}"
+                        "value": "{theme.color.palette.slate.30.value}"
                     },
                     "icon": {
-                        "value": "{theme.color.palette.slate.40.value}"
+                        "value": "{theme.color.palette.slate.30.value}"
                     }
                 }
             },
             "secondary": {
                 "disabled": {
                     "background": {
-                        "value": "{theme.color.palette.slate.70.value}"
+                        "value": "{theme.color.palette.slate.50.value}"
                     },
                     "border": {
-                        "value": "{theme.color.palette.slate.70.value}"
+                        "value": "{theme.color.palette.slate.50.value}"
                     },
                     "font": {
-                        "value": "{theme.color.palette.slate.40.value}"
+                        "value": "{theme.color.palette.slate.30.value}"
                     },
                     "icon": {
-                        "value": "{theme.color.palette.slate.40.value}"
+                        "value": "{theme.color.palette.slate.30.value}"
                     }
                 },
                 "initial": {

--- a/design-tokens/theme-uplift/variants/contrast/props/input.json
+++ b/design-tokens/theme-uplift/variants/contrast/props/input.json
@@ -1,6 +1,11 @@
 {
     "input": {
         "color": {
+            "initial": {
+                "background": {
+                    "value": "{theme.color.palette.white}"
+                }
+            },
             "readonly": {
                 "background": {
                     "value": "{theme.color.brand.secondary.base.value}"

--- a/design-tokens/theme-uplift/variants/contrast/props/input.json
+++ b/design-tokens/theme-uplift/variants/contrast/props/input.json
@@ -1,17 +1,25 @@
 {
     "input": {
         "color": {
+            "disabled": {
+                "border": {
+                    "value": "{theme.color.palette.slate.50.value}"
+                },
+                "font": {
+                    "value": "{theme.color.palette.slate.50.value}"
+                }
+            },
             "initial": {
                 "background": {
-                    "value": "{theme.color.palette.white}"
+                    "value": "{theme.color.palette.white.value}"
                 }
             },
             "readonly": {
                 "background": {
-                    "value": "{theme.color.brand.secondary.base.value}"
+                    "value": "{theme.color.palette.slate.40.value}"
                 },
                 "font": {
-                    "value": "{theme.color.brand.primary.contrast.value}"
+                    "value": "{theme.color.palette.slate.100.value}"
                 }
             }
         }

--- a/design-tokens/theme-uplift/variants/contrast/theme.json
+++ b/design-tokens/theme-uplift/variants/contrast/theme.json
@@ -11,12 +11,12 @@
             "brand": {
                 "primary": {
                     "base":     { "value": "{theme.color.palette.azure.90.value}" },
-                    "alt":      { "value": "{theme.color.palette.azure.100.value}" }                
+                    "alt":      { "value": "{theme.color.palette.azure.100.value}" }
                 },
                 "secondary": {
                     "lighter": { "value": "{theme.color.palette.slate.80.value}" },
                     "base":     { "value": "{theme.color.palette.slate.90.value}" },
-                    "alt":      { "value": "{theme.color.palette.slate.100.value}" }                
+                    "alt":      { "value": "{theme.color.palette.slate.100.value}" }
                 }
             },
             "border": {

--- a/design-tokens/theme-uplift/variants/dark/props/input.json
+++ b/design-tokens/theme-uplift/variants/dark/props/input.json
@@ -1,12 +1,20 @@
 {
     "input": {
         "color": {
+            "disabled": {
+                "border": {
+                    "value": "{theme.color.palette.slate.70.value}"
+                },
+                "font": {
+                    "value": "{theme.color.palette.slate.70.value}"
+                }
+            },
             "readonly": {
                 "background": {
                     "value": "{theme.color.brand.secondary.alt.value}"
                 }
             }
         }
-        
+
     }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds some more token changes that affect Uplift Contrast:
- Brightens colors for Uplift Contrast disabled button styles
- Makes Uplift Contrast standard input fields white instead of transparent
- Dims colors used on Uplift Contrast/Dark disabled input fields (fades it into background)
- Brightens background color on Uplift Contrast readonly input fields

**Related github/jira issue (required)**:
Closes #404
