### PR TITLE
Brighten placeholder color on Uplift Dark

### DIFF
--- a/design-tokens/theme-uplift/variants/dark/props/input.json
+++ b/design-tokens/theme-uplift/variants/dark/props/input.json
@@ -9,6 +9,11 @@
                     "value": "{theme.color.palette.slate.70.value}"
                 }
             },
+            "initial": {
+                "placeholder": {
+                    "value": "{theme.color.palette.slate.60.value}"
+                }
+            },
             "readonly": {
                 "background": {
                     "value": "{theme.color.brand.secondary.alt.value}"


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR brightens up the color of the Input field's placeholder text on the Uplift Dark theme.

**Related github/jira issue (required)**:
Closes #404
Related to infor-design/enterprise#2708