### PR TITLE
add xxs font size to theme css

### DIFF
--- a/design-tokens/theme-classic/theme.json
+++ b/design-tokens/theme-classic/theme.json
@@ -59,7 +59,7 @@
         "size": {
             "font": {
                 "base": { "value": "{ids.size.font.md.value}" },
-                "xxs":   { "value": "1.0rem" },
+                "xxs":   { "value": "0.8rem" },
                 "xs":   { "value": "1.0rem" },
                 "sm":   { "value": "1.2rem" },
                 "md":   { "value": "1.4rem" },

--- a/design-tokens/theme-classic/theme.json
+++ b/design-tokens/theme-classic/theme.json
@@ -59,6 +59,7 @@
         "size": {
             "font": {
                 "base": { "value": "{ids.size.font.md.value}" },
+                "xxs":   { "value": "1.0rem" },
                 "xs":   { "value": "1.0rem" },
                 "sm":   { "value": "1.2rem" },
                 "md":   { "value": "1.4rem" },

--- a/design-tokens/theme-new/theme.json
+++ b/design-tokens/theme-new/theme.json
@@ -59,6 +59,7 @@
         "size": {
             "font": {
                 "base": { "value": "{ids.size.font.sm.value}" },
+                "xxs":   { "value": "1.0rem" },
                 "xs":   { "value": "1.4rem" },
                 "sm":   { "value": "1.6rem" },
                 "md":   { "value": "2.2rem" },

--- a/design-tokens/theme-new/theme.json
+++ b/design-tokens/theme-new/theme.json
@@ -59,7 +59,7 @@
         "size": {
             "font": {
                 "base": { "value": "{ids.size.font.sm.value}" },
-                "xxs":   { "value": "1.0rem" },
+                "xxs":   { "value": "1.2rem" },
                 "xs":   { "value": "1.4rem" },
                 "sm":   { "value": "1.6rem" },
                 "md":   { "value": "2.2rem" },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

Font sizes in our new theme do not match Infor Design Typography page, changing the existing font sizes might cause unknown effects, so I would like to add a new font size until we fully migrate to webcomponent some time in the future: 

![image](https://user-images.githubusercontent.com/82842191/223162051-5c1d006b-21fb-4f07-ab38-2262bd2fda49.png)


**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->

add xxs to have font size 12 pixels for us to match product design with infor design system.


**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

use class="font-size-xss" in div or span, font size should be 12 pixels if using theme new css.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
